### PR TITLE
Changed the select icon to something that hopefully is more clear.

### DIFF
--- a/src/umr/templates/article.html
+++ b/src/umr/templates/article.html
@@ -38,7 +38,7 @@
 				<i class="material-icons">undo</i>
 			</button>
 			<button id = "toggle_copy" class="mdl-button mdl-js-button mdl-button--icon mdl-layout-icon">
-				<i class="material-icons">content_copy</i>
+				<i class="material-icons">format_shapes</i>
 			</button>
 			<button id = "toggle_star" class="mdl-button mdl-js-button mdl-button--icon mdl-layout-icon">
 				<i class="material-icons star">star_border</i>
@@ -49,7 +49,7 @@
 
 <!-- Article content. -->
   <main class="mdl-layout__content">
-	<div class="page-content-container"> 
+	<div class="page-content-container">
 		<div class="content-container">
 			<div class="page-content">
 				<p class="title translatable">
@@ -57,8 +57,8 @@
 				</p>
 				<p id="articleInfo">
 					<span id="articleURL">From: <a target="_blank">source</a></span>
-				</p>	
-				<div id="articleContent" class="translatable"></div><br />		
+				</p>
+				<div id="articleContent" class="translatable"></div><br />
 			</div>
 		</div>
 		<div id = "like_button">
@@ -67,7 +67,7 @@
 			</button>
 		</div>
 	</div>
-    
+
   </main>
   <div id="toastmessage" class="mdl-js-snackbar mdl-snackbar">
 	  <div class="mdl-snackbar__text"></div>


### PR DESCRIPTION
Changed the select button to this:
![image](https://user-images.githubusercontent.com/10974297/29741121-c62d5474-8a66-11e7-9b53-5d8903cc2e77.png)
I tried the hand icon, but it felt even more confusing. I also wanted something that is disabled by default (light grey is less distracting than full black).
This icon seemed to convey the select-text-mode best.